### PR TITLE
fix(2fa): fallback to sender as read from imessage db

### DIFF
--- a/2fa-read-code/src/index.js
+++ b/2fa-read-code/src/index.js
@@ -58,7 +58,7 @@ const wf = new Workflow();
             utils.buildItem({
               title: `${captcha}`,
               subtitle: `${
-                subject ? `Sender：${subject} ` : ''
+                subject ? `Sender：${subject}, ` : `Sender: ${messageObj.sender}, `
               }${dateUtils.formatToCalendar(
                 messageObj.message_date
               )}，⏎ to Copy`,


### PR DESCRIPTION
This fixes the case, where the message does not contain a sender in the form ` [ senderName ] `: previously, the search result showed *no* sender information if this pattern is missing, now it falls back to the sender as read from the sqlite db containing the message.