### PR TITLE
fix(appid): remove duplicate App ID / App Version entries from File Actions list

### DIFF
--- a/appid/src/info.plist
+++ b/appid/src/info.plist
@@ -279,6 +279,8 @@ puts({ items: script_filter_items }.to_json)
 				<string>Show App ID of installed apps</string>
 				<key>title</key>
 				<string>App ID</string>
+				<key>treatInputAsUniversalAction</key>
+				<false/>
 				<key>type</key>
 				<integer>2</integer>
 				<key>withspace</key>
@@ -490,6 +492,8 @@ puts({ items: script_filter_items }.to_json)
 				<string>Show version number of installed apps</string>
 				<key>title</key>
 				<string>App Version</string>
+				<key>treatInputAsUniversalAction</key>
+				<false/>
 				<key>type</key>
 				<integer>0</integer>
 				<key>withspace</key>


### PR DESCRIPTION
Fixes alfred-workflows#454

Disable 'Treat Input as Universal Action' on the `appid` and `av` Script Filters so they no longer appear in Alfred's File Actions list. Standalone File Actions with the same names already exist, which produced duplicate entries and forced the slower full-`/Applications` script filter path when picked from the list.

Changes
- `appid/src/info.plist`: set `treatInputAsUniversalAction = false` on Script Filter UIDs `56E911C8-…` (App ID) and `73372C83-…` (App Version).
- `appid/AppID.alfredworkflow`: rebuilt bundle.

Behavior after this change
- Right-clicking a `.app` shows exactly four File Actions: App ID, App Name, App Version, App Icon (no duplicates).
- The keyword entry points (`appid` / `av`) continue to work from Alfred's main input.
- Standalone File Action path (single `osascript` / `mdls` call per file) is used, removing the slowdown.