### PR TITLE
AOL-830: fix AppID file action version lookup

### DIFF
--- a/appid/src/index.js
+++ b/appid/src/index.js
@@ -15,6 +15,8 @@ const wf = new Workflow();
 (function () {
   if (action === 'av') {
     listAppVersions();
+  } else if (action === 'appversion') {
+    getAppVersion(query);
   } else if (action === 'appicon') {
     getAppIconPath(query);
   }
@@ -23,10 +25,8 @@ const wf = new Workflow();
 function listAppVersions() {
   const apps = convertToApps(execSync('ls /Applications ', {encoding: 'utf-8'}), '/Applications').concat(convertToApps(execSync('ls /Applications/Utilities', {encoding: 'utf-8'}), '/Applications/Utilities'));
   for (let index = 0; index < apps.length; index++) {
-    const command = `mdls -raw -name kMDItemVersion  -name kMDItemAppStoreHasReceipt "${apps[index].path}"`;
-    const [receipt, version] = execSync(command, {
-      encoding: 'utf-8'
-    }).split('\x00');
+    const version = readAppVersion(apps[index].path);
+    const receipt = runCommand(`mdls -raw -name kMDItemAppStoreHasReceipt "${apps[index].path}"`);
     wf.addWorkflowItem({
       item: {
         title: apps[index].name, icon: {
@@ -46,6 +46,33 @@ function convertToApps(ouputstr, basePath) {
     .map((app) => ({
       name: app, path: path.join(basePath, app)
     }));
+}
+
+function getAppVersion(appPath) {
+  const version = readAppVersion(appPath);
+  utils.log(version);
+}
+
+function readAppVersion(appPath) {
+  if (!appPath) {
+    return '';
+  }
+
+  const mdlsVersion = runCommand(`mdls -raw -name kMDItemVersion "${appPath}"`);
+  if (mdlsVersion && mdlsVersion !== '(null)') {
+    return mdlsVersion;
+  }
+
+  const appInfo = plist.parse(fs.readFileSync(path.join(appPath, 'Contents/Info.plist'), 'utf8'));
+  return appInfo.CFBundleShortVersionString || appInfo.CFBundleVersion || '';
+}
+
+function runCommand(command) {
+  try {
+    return execSync(command, {encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore']}).trim();
+  } catch (error) {
+    return '';
+  }
 }
 
 function getAppIconPath(appPath) {

--- a/appid/src/info.plist
+++ b/appid/src/info.plist
@@ -565,9 +565,9 @@ puts({ items: script_filter_items }.to_json)
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>mdls -raw -name kMDItemVersion "${1}"</string>
+				<string>node ./index.js appversion '{query}'</string>
 				<key>scriptargtype</key>
-				<integer>1</integer>
+				<integer>0</integer>
 				<key>scriptfile</key>
 				<string></string>
 				<key>type</key>


### PR DESCRIPTION
## Summary
- route App Version file action through the Node workflow script with the correct Alfred query mode
- add a shared version lookup that falls back from Spotlight metadata to app Info.plist
- rebuild AppID.alfredworkflow with the updated source files

## Validation
- node --check appid/src/index.js
- node ./index.js appversion /tmp/aol-830-test.app
- unzip -t appid/AppID.alfredworkflow
- extracted packaged workflow and ran node ./index.js appversion /tmp/aol-830-test.app

Closes AOL-830