### PR TITLE
AOL-831: surface 2FA script errors directly

### DIFF
--- a/2fa-read-code/README.md
+++ b/2fa-read-code/README.md
@@ -11,8 +11,6 @@
 2. Grant `Full Disk Access` to Alfred in `System Settings > Privacy & Security > Full Disk Access`, then restart Alfred
 3. sqlite3 >=v3.33.0
 
-If the workflow reports `authorization denied` for `~/Library/Messages/chat.db`, macOS is blocking Alfred from reading the Messages database. Re-check the Full Disk Access setting above.
-
 
 ## Big Sur Issue
 

--- a/2fa-read-code/README.md
+++ b/2fa-read-code/README.md
@@ -8,8 +8,10 @@
 ## Requirement
 
 1. `brew install node`
-2. Alfred has permission to `Full Disk Access`
+2. Grant `Full Disk Access` to Alfred in `System Settings > Privacy & Security > Full Disk Access`, then restart Alfred
 3. sqlite3 >=v3.33.0
+
+If the workflow reports `authorization denied` for `~/Library/Messages/chat.db`, macOS is blocking Alfred from reading the Messages database. Re-check the Full Disk Access setting above.
 
 
 ## Big Sur Issue

--- a/2fa-read-code/src/info.plist
+++ b/2fa-read-code/src/info.plist
@@ -256,8 +256,6 @@
 2. Grant `Full Disk Access` to Alfred in `System Settings &gt; Privacy &amp; Security &gt; Full Disk Access`, then restart Alfred
 3. sqlite3 &gt;=v3.33.0
 
-If the workflow reports `authorization denied` for `~/Library/Messages/chat.db`, macOS is blocking Alfred from reading the Messages database. Re-check the Full Disk Access setting above.
-
 
 ## Big Sur Issue
 

--- a/2fa-read-code/src/info.plist
+++ b/2fa-read-code/src/info.plist
@@ -253,8 +253,10 @@
 ## Requirement
 
 1. `brew install node`
-2. Alfred has permission to `Full Disk Access`
+2. Grant `Full Disk Access` to Alfred in `System Settings &gt; Privacy &amp; Security &gt; Full Disk Access`, then restart Alfred
 3. sqlite3 &gt;=v3.33.0
+
+If the workflow reports `authorization denied` for `~/Library/Messages/chat.db`, macOS is blocking Alfred from reading the Messages database. Re-check the Full Disk Access setting above.
 
 
 ## Big Sur Issue

--- a/2fa-read-code/src/node-imessage.js
+++ b/2fa-read-code/src/node-imessage.js
@@ -25,32 +25,9 @@ class iMessage {
   exec(dbStr) {
     fs.writeFileSync(this.sqlPath, dbStr);
     let command = `sqlite3 "${this.path}" < "${this.sqlPath}" -json`;
-    let resStr;
-    try {
-      resStr = childProcess.execSync(command, { encoding: 'utf8' });
-    } catch (e) {
-      if (isDatabaseAuthorizationError(e)) {
-        throw new Error(buildDatabasePermissionError());
-      }
-      throw e;
-    }
+    const resStr = childProcess.execSync(command, { encoding: 'utf8' });
     return resStr ? JSON.parse(resStr) : [];
   }
-}
-
-function isDatabaseAuthorizationError(error) {
-  const stderr = error?.stderr?.toString?.() || '';
-  const message = error?.message || '';
-  return /authorization denied|operation not permitted|permission denied/i.test(`${stderr}\n${message}`)
-    && /Library\/Messages\/chat\.db|Messages\/chat\.db/i.test(`${stderr}\n${message}`);
-}
-
-function buildDatabasePermissionError() {
-  return [
-    'Cannot open Messages database.',
-    'Grant Full Disk Access to Alfred in System Settings > Privacy & Security > Full Disk Access,',
-    'then restart Alfred and run 2FA-Read Code again.'
-  ].join(' ');
 }
 
 function getUserHome() {

--- a/2fa-read-code/src/node-imessage.js
+++ b/2fa-read-code/src/node-imessage.js
@@ -1,10 +1,11 @@
 const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
+const os = require('os');
 
 const HOME = getUserHome();
 const DB_PATH = path.join(HOME, '/Library/Messages/chat.db');
-const SQL_PATH = path.join(process.env.alfred_workflow_cache, 'select.sql');
+const SQL_PATH = path.join(process.env.alfred_workflow_cache || os.tmpdir(), 'select.sql');
 
 class iMessage {
   constructor() {
@@ -24,9 +25,32 @@ class iMessage {
   exec(dbStr) {
     fs.writeFileSync(this.sqlPath, dbStr);
     let command = `sqlite3 "${this.path}" < "${this.sqlPath}" -json`;
-    const resStr = childProcess.execSync(command, { encoding: 'utf8' });
+    let resStr;
+    try {
+      resStr = childProcess.execSync(command, { encoding: 'utf8' });
+    } catch (e) {
+      if (isDatabaseAuthorizationError(e)) {
+        throw new Error(buildDatabasePermissionError());
+      }
+      throw e;
+    }
     return resStr ? JSON.parse(resStr) : [];
   }
+}
+
+function isDatabaseAuthorizationError(error) {
+  const stderr = error?.stderr?.toString?.() || '';
+  const message = error?.message || '';
+  return /authorization denied|operation not permitted|permission denied/i.test(`${stderr}\n${message}`)
+    && /Library\/Messages\/chat\.db|Messages\/chat\.db/i.test(`${stderr}\n${message}`);
+}
+
+function buildDatabasePermissionError() {
+  return [
+    'Cannot open Messages database.',
+    'Grant Full Disk Access to Alfred in System Settings > Privacy & Security > Full Disk Access,',
+    'then restart Alfred and run 2FA-Read Code again.'
+  ].join(' ');
 }
 
 function getUserHome() {


### PR DESCRIPTION
## Summary
- remove the permission-specific sqlite error mapping so script failures surface through the normal Alfred item error path
- keep the safer SQL cache fallback for local/test execution outside Alfred
- keep README and embedded workflow help focused on the general Full Disk Access requirement
- update the packaged 2FA-Read Code workflow archive

## Tests
- npm test
- node -e targeted raw sqlite error check

Fixes #453
Closes AOL-831